### PR TITLE
Fix karma/env? call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.3.5
 
-- Update `doo` to version 0.1.8
+- Update `doo` to version 0.1.9
 
 ## 0.3.4
 

--- a/example/build.boot
+++ b/example/build.boot
@@ -2,9 +2,9 @@
   :source-paths #{"src"}
   :resource-paths #{"resources"}
   :dependencies
-  '[[org.clojure/clojure "1.8.0"]
-    [crisptrutski/boot-cljs-test "0.3.5-SNAPSHOT" :scope "test"]
-    [adzerk/boot-test            "1.2.0"]])
+  '[[org.clojure/clojure               "1.8.0"]
+    [org.clojars.miikka/boot-cljs-test "0.3.5-SNAPSHOT" :scope "test"]
+    [adzerk/boot-test                  "1.2.0"]])
 
 (require
   '[adzerk.boot-test            :refer :all]

--- a/src/crisptrutski/boot_cljs_test.clj
+++ b/src/crisptrutski/boot_cljs_test.clj
@@ -172,7 +172,7 @@
     (doseq [id ids]
       (when (> (count ids) 1) (info? verbosity "• %s\n" id))
       (let [filename (u/os-path (str id ".js"))
-            karma? ((u/r doo.karma/env?) js-env)
+            karma? ((u/r doo.karma/env?) js-env doo-opts)
             output-to (u/find-path fileset filename)
             output-dir (when output-to (str/replace output-to #"\.js\z" ".out"))
             asset-path (when (u/asset-path?) (u/asset-path id cljs-opts))
@@ -303,7 +303,7 @@
         (normalize-task-opts
           (named-map ids js-env namespaces exclusions cljs-opts optimizations doo-opts verbosity out-file symlink? exit?))
         ;; karma process is external, so coordinating rollback is not feasible.
-        update-fs? (or update-fs? ((u/r doo.karma/env?) js-env))]
+        update-fs? (or update-fs? ((u/r doo.karma/env?) js-env doo-opts))]
     (fcomp
       (when-not update-fs? (fs-snapshot))
       (for [id ids] (-prep-cljs-tests id task-opts))


### PR DESCRIPTION
The `karma/env?` signature has changed with the support for custom Karma launchers.